### PR TITLE
Remove the statisticEnabled property for the documentIntelilgence module

### DIFF
--- a/infra/modules/docIntelligence.bicep
+++ b/infra/modules/docIntelligence.bicep
@@ -22,8 +22,6 @@ resource aiServices 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
   }
   kind: 'FormRecognizer' // or 'OpenAI'
   properties: {
-    apiProperties: {
-      statisticsEnabled: false
-    }
+
   }
 }


### PR DESCRIPTION
While deploying the main.bicep it's throwing the following error 

```
{"code": "InvalidTemplateDeployment", "message": "The template deployment 'main' is not valid according to the validation procedure. The tracking id is 'd7b1576f-81b2-4c49-9927-6c44390467ce'. See inner errors for details."}

Inner Errors:
{"code": "ApiPropertiesInvalid", "message": "The given 'apiProperties' 'statisticsEnabled' is invalid. Validation errors: Property 'statisticsEnabled' has not been defined and the schema does not allow additional properties. Path 'apiProperties.statisticsEnabled'."}
```

And that's because of the statisticsEnabled for the `./module/documentIntelligent.bicep`
Based on the Microsoft docs here [https://learn.microsoft.com/en-us/azure/templates/microsoft.cognitiveservices/2023-05-01/accounts?pivots=deployment-language-bicep#apiproperties](https://learn.microsoft.com/en-us/azure/templates/microsoft.cognitiveservices/2023-05-01/accounts?pivots=deployment-language-bicep#apiproperties)