### PR TITLE
Update dependant-resources.bicep

### DIFF
--- a/infra/modules/dependant-resources.bicep
+++ b/infra/modules/dependant-resources.bicep
@@ -138,7 +138,7 @@ param storageSkuName string = 'Standard_LRS'
 
 var storageNameCleaned = replace(storageName, '-', '')
 
-resource aiServices 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
+resource aiServices 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
   name: aiServicesName
   location: location
   sku: {
@@ -146,9 +146,10 @@ resource aiServices 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
   }
   kind: 'AIServices' // or 'OpenAI'
   properties: {
-    apiProperties: {
-      statisticsEnabled: false
-    }
+  //  apiProperties: {
+  //   statisticsEnabled: false
+  //  }
+  // No apiProperties needed for AIServices kind
   }
 }
 


### PR DESCRIPTION
I'm updating the API version and commenting out the apiProperties because as you mention in the comment "No apiProperties needed for AIServices kind" this makes the whole deployment fail with an error difficult to understand (see below). I think it's more user friendly to make the deployment succeed from the first go rather than have to deep dive into the code and change this manually :)

{"code": "InvalidTemplateDeployment", "message": "The template deployment 'main' is not valid according to the validation procedure. The tracking id is '129ff1eb-e906-4f49-852a-201ec216375a'. See inner errors for details."}

Inner Errors: 
{"code": "ApiPropertiesInvalid", "message": "The given 'apiProperties' 'statisticsEnabled' is invalid. Validation errors: Property 'statisticsEnabled' has not been defined and the schema does not allow additional properties. Path 'apiProperties.statisticsEnabled'."}